### PR TITLE
Allow connections from Mirakel.

### DIFF
--- a/scripts/vagrant/simple_taskd_configuration.conf
+++ b/scripts/vagrant/simple_taskd_configuration.conf
@@ -12,4 +12,4 @@ server.key=/var/taskd/server.key.pem
 server.crl=/var/taskd/server.crl.pem
 ca.key=/var/taskd/ca.key.pem
 ca.cert=/var/taskd/ca.cert.pem
-client.allow=^task [2-9]
+client.allow=^task [2-9],^taskd,^libtaskd,^Mirakel [1-9]


### PR DESCRIPTION
Since inthe.am's internal taskd is version 1.0.0, clients other than taskwarrior have to be explicitly allowed. 

This addresses [MIR-532](https://mirakel.atlassian.net/browse/MIR-532).

On a server that's already running, updating the config and then sending SIGHUP should take care of it (and would be greatly appreciated even if this doesn't merge <3).

``` bash
taskd config --force --data root/ client.allow '^task [2-9],^taskd,^libtaskd,^Mirakel [1-9]'
pkill -1 taskd
```
