### PR TITLE
allows uda.priority.default in local taskrc

### DIFF
--- a/inthe_am/taskmanager/models/taskstore.py
+++ b/inthe_am/taskmanager/models/taskstore.py
@@ -297,6 +297,10 @@ class TaskStore(models.Model):
                 self._is_valid_priority
             ),
             (
+                re.compile('^priority\.default$'),
+                self._is_valid_priority
+            ),
+            (
                 re.compile('^uda\.[^.]+\.type$'),
                 self._is_valid_type
             ),

--- a/inthe_am/taskmanager/models/taskstore.py
+++ b/inthe_am/taskmanager/models/taskstore.py
@@ -265,6 +265,11 @@ class TaskStore(models.Model):
             return True
         return False
 
+    def _is_valid_priority(self, val):
+        if val in ('H', 'M', 'L'):
+            return True
+        return False
+
     def _get_extra_safely(self, key, val):
         valid_patterns = [
             (
@@ -286,6 +291,10 @@ class TaskStore(models.Model):
             (
                 re.compile('^urgency\.uda\.[^.]+\.coefficient$'),
                 self._is_numeric
+            ),
+            (
+                re.compile('^uda\.priority\.default$'),
+                self._is_valid_priority
             ),
             (
                 re.compile('^uda\.[^.]+\.type$'),


### PR DESCRIPTION
This allows the key **uda.priority.default** to by used in the custom .taskrc. Value is checked to be one of "H", "M", "L"