### PR TITLE
Surround the API key in a span tag to identify it semantically

### DIFF
--- a/app/templates/configure.hbs
+++ b/app/templates/configure.hbs
@@ -278,7 +278,7 @@
                                         API Key
                                     </th>
                                     <td>
-                                        {{ applicationController.user.api_key }}
+                                        <span id="rest_api_key">{{ applicationController.user.api_key }}</span>
                                     </td>
                                 </tr>
                             </table>


### PR DESCRIPTION
Allows the API key to be more easily parsed from the page in a future-proof way, for example by browser extensions that might want this information.