### PR TITLE
Updated incorrect CA certificate file name

### DIFF
--- a/ui/src/components/SyncInstructions.tsx
+++ b/ui/src/components/SyncInstructions.tsx
@@ -52,7 +52,7 @@ const SyncInstructions: FunctionComponent = () => {
             <tr>
               <th>Server Certificate</th>
               <td>
-                <a href={caCertificate}>ca.cert.pem</a>
+                <a href={caCertificate}>ca.crt</a>
               </td>
             </tr>
           )}
@@ -69,7 +69,7 @@ const SyncInstructions: FunctionComponent = () => {
         <br />
         taskd.key=/path/to/private.key.pem
         <br />
-        taskd.ca=/path/to/ca.cert.pem
+        taskd.ca=/path/to/ca.crt
         <br />
         taskd.server={taskdServer}
         <br />


### PR DESCRIPTION
Sync configuration instructions have invalid file names listed for the CA certificate. The certificate file is ca.crt, not ca.cert.pem as noted in the instructions.